### PR TITLE
Hotfix: Set Map URL for production

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "build:translations": "formatjs compile-folder --format crowdin --ast messages src/translations",
     "build:storybook": "build-storybook -s public",
     "deploy": "npm run build && firebase deploy -P staging",
+    "deploy:prod": "npm run build && firebase deploy -P production",
     "storybook": "start-storybook -p 9009 -s public",
     "extract-messages": "formatjs extract --format crowdin 'src/**/*.ts*' --out-file messages/en.json",
     "prepare": "husky install",

--- a/src/views/Map/index.tsx
+++ b/src/views/Map/index.tsx
@@ -14,8 +14,8 @@ import { Header } from './Header'
 import { IFrame } from './styles'
 import { Loader } from '../../components/Loader'
 
-const SHARE_URL_BASE = 'https://deploy-preview-30--mapeo-webmaps.netlify.app' // DEV URL (You'll need to run Webmaps-Public locally on port 9966)
-// const SHARE_URL_BASE = 'https://maps-public.mapeo.world' // PROD URL
+// const SHARE_URL_BASE = 'https://deploy-preview-30--mapeo-webmaps.netlify.app' // DEV URL
+const SHARE_URL_BASE = 'https://maps-public.mapeo.world' // PROD URL
 
 export const MapView = ({}: RouteComponentProps) => {
   const [shareModalOpen, setShareModalOpen] = useState(false)


### PR DESCRIPTION
Map URL was pointing at the staging server, so 404ing when trying to view a map on prod site.

closes https://github.com/digidem/mapeo-webmaps/issues/97